### PR TITLE
曲再生時の共有された曲を保存するメソッド作成とAPIへの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
 
+  gem "pry-rails"
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 end
@@ -49,5 +50,3 @@ end
 gem "devise", "~> 4.9"
 
 gem "devise-jwt", "~> 0.12.1"
-
-gem "pry-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -49,3 +49,5 @@ end
 gem "devise", "~> 4.9"
 
 gem "devise-jwt", "~> 0.12.1"
+
+gem 'pry-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -50,4 +50,4 @@ gem "devise", "~> 4.9"
 
 gem "devise-jwt", "~> 0.12.1"
 
-gem 'pry-rails'
+gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     brakeman (7.1.0)
       racc
     builder (3.3.0)
+    coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crass (1.0.6)
@@ -154,6 +155,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.1.0)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -198,6 +200,11 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     prism (1.5.1)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.11)
+      pry (>= 0.13.0)
     psych (5.2.6)
       date
       stringio
@@ -357,6 +364,7 @@ DEPENDENCIES
   devise-jwt (~> 0.12.1)
   kamal
   mysql2 (>= 0.5)
+  pry-rails
   puma (>= 5.0)
   rack-cors
   rails (~> 8.0.3)

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -2,7 +2,8 @@ class Songs::SongsController < ApplicationController
   def show
     song_data = PlaySongService.call(
       song_id: params[:id],
-      share_id: params[:share_id]
+      share_id: params[:share_id],
+      user_id: current_user.id
     )
     if song_data
       render json: song_data, status: :ok

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -3,7 +3,7 @@ class Songs::SongsController < ApplicationController
     song_data = PlaySongService.call(
       song_id: params[:id],
       share_id: params[:share_id],
-      user_id: current_user.id
+      user_id: current_user&.id
     )
     if song_data
       render json: song_data, status: :ok

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -1,6 +1,6 @@
 class Songs::SongsController < ApplicationController
   def show
-    song_data = FetchSongService.call(
+    song_data = PlaySongService.call(
       song_id: params[:id],
       share_id: params[:share_id]
     )

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,3 +1,4 @@
 class Song < ApplicationRecord
   belongs_to :artist
+  has_many :UsersSharedSong
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
          :jwt_authenticatable, jwt_revocation_strategy: JwtDenylist
   before_create :generate_share_id
 
+  has_many :UsersSharedSong
   private
 
   def generate_share_id

--- a/app/models/users_shared_song.rb
+++ b/app/models/users_shared_song.rb
@@ -1,0 +1,4 @@
+class UsersSharedSong < ApplicationRecord
+  belongs_to :user
+  belongs_to :song
+end

--- a/app/services/play_song_service.rb
+++ b/app/services/play_song_service.rb
@@ -1,4 +1,4 @@
-class FetchSongService
+class PlaySongService
   include Callable
     def initialize(song_id:, share_id: nil)
       @song_id = song_id

--- a/app/services/play_song_service.rb
+++ b/app/services/play_song_service.rb
@@ -1,15 +1,20 @@
 class PlaySongService
   include Callable
-    def initialize(song_id:, share_id: nil)
-      @song_id = song_id
+    def initialize(song_id:, user_id: nil, share_id: nil)
+      @song_id = song_id,
+      @user_id = user_id,
       @share_id = share_id
     end
 
     def call
       song = fetch_song_and_artist_name(@song_id)
       return nil unless song
-      increment_shared_count if @share_id.present?
-
+      if @share_id.present?
+        increment_shared_count
+      end
+      if @user_id.present?
+        save_shared_song
+      end
       song
     end
 
@@ -37,5 +42,11 @@ class PlaySongService
       shared_count.save
     end
 
-    
+    def save_shared_song
+      shared_song = UsersSharedSong.find_or_initialize_by(
+        user_id: @user_id,
+        song_id: @song_id
+        )
+      shared_song.save
+    end
 end

--- a/app/services/play_song_service.rb
+++ b/app/services/play_song_service.rb
@@ -36,4 +36,6 @@ class PlaySongService
       shared_count.count += 1
       shared_count.save
     end
+
+    
 end

--- a/app/services/play_song_service.rb
+++ b/app/services/play_song_service.rb
@@ -1,8 +1,9 @@
 class PlaySongService
   include Callable
+  # require 'pry-rails'
     def initialize(song_id:, user_id: nil, share_id: nil)
-      @song_id = song_id,
-      @user_id = user_id,
+      @song_id = song_id
+      @user_id = user_id
       @share_id = share_id
     end
 
@@ -15,6 +16,7 @@ class PlaySongService
       if @user_id.present?
         save_shared_song
       end
+      # binding.irb
       song
     end
 

--- a/app/services/play_song_service.rb
+++ b/app/services/play_song_service.rb
@@ -1,6 +1,6 @@
 class PlaySongService
   include Callable
-  # require 'pry-rails'
+    # require 'pry-rails'
     def initialize(song_id:, user_id: nil, share_id: nil)
       @song_id = song_id
       @user_id = user_id

--- a/app/services/play_song_service.rb
+++ b/app/services/play_song_service.rb
@@ -1,6 +1,5 @@
 class PlaySongService
   include Callable
-    # require 'pry-rails'
     def initialize(song_id:, user_id: nil, share_id: nil)
       @song_id = song_id
       @user_id = user_id
@@ -16,7 +15,6 @@ class PlaySongService
       if @user_id.present?
         save_shared_song
       end
-      # binding.irb
       song
     end
 

--- a/db/migrate/20251005072935_create_users_shared_songs.rb
+++ b/db/migrate/20251005072935_create_users_shared_songs.rb
@@ -1,0 +1,10 @@
+class CreateUsersSharedSongs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :users_shared_songs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :song, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_05_025430) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_05_072935) do
   create_table "artists", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "picture_url"
     t.string "spotify_url"
@@ -66,6 +66,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_05_025430) do
     t.index ["share_id"], name: "index_users_on_share_id", unique: true
   end
 
+  create_table "users_shared_songs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "song_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["song_id"], name: "index_users_shared_songs_on_song_id"
+    t.index ["user_id"], name: "index_users_shared_songs_on_user_id"
+  end
+
   add_foreign_key "shared_counts", "songs"
   add_foreign_key "songs", "artists"
+  add_foreign_key "users_shared_songs", "songs"
+  add_foreign_key "users_shared_songs", "users"
 end

--- a/test/fixtures/users_shared_songs.yml
+++ b/test/fixtures/users_shared_songs.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  song: one
+
+two:
+  user: two
+  song: two

--- a/test/models/users_shared_song_test.rb
+++ b/test/models/users_shared_song_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersSharedSongTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 実施したタスク

1. users_shared_songsテーブルとモデルの作成
2. 楽曲情報取得時にテーブルにログインしているユーザーIDとsong_idを保存する処理をAPIに追加

## エンドポイント
http://localhost:3000/player/songs/1&share_id=17b787320959514a

## 詳細
曲を共有されたとき、userがログインしていれば、user_idとsong_idを保存して、後から聞き返せるようにするためのメソッドを作成。API自体は曲情報取得と統一して、serviceのインスタンス生成時にuser_idがあれば実行されるサブメソッドを作成。
