### PR TITLE
共有された楽曲取得APIの作成

### DIFF
--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -1,5 +1,5 @@
 class Songs::SongsController < ApplicationController
-  before_action :authenticate_user!, only: [:show_shared_song]
+  before_action :authenticate_user!, only: [ :show_shared_song ]
   def show
     song_data = PlaySongService.call(
       song_id: params[:id],
@@ -20,7 +20,7 @@ class Songs::SongsController < ApplicationController
     if shared_song_data.present?
       render json: shared_song_data, status: :ok
     else
-      render json: { shared_song_data: [], "message": 共有された曲はまだありません}, status: :ok
+      render json: { shared_song_data: [], "message": 共有された曲はまだありません }, status: :ok
     end
   end
 end

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -20,7 +20,7 @@ class Songs::SongsController < ApplicationController
     if shared_song_data.present?
       render json: shared_song_data, status: :ok
     else
-      render json: { shared_song_data: [], "message": 共有された曲はまだありません }, status: :ok
+      render json: { shared_song_data: [], "message": "共有された曲はまだありません" }, status: :ok
     end
   end
 end

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -1,4 +1,5 @@
 class Songs::SongsController < ApplicationController
+  before_action :authenticate_user!, only: [:show_shared_song]
   def show
     song_data = PlaySongService.call(
       song_id: params[:id],
@@ -9,6 +10,17 @@ class Songs::SongsController < ApplicationController
       render json: song_data, status: :ok
     else
       render json: { error: "Song not found" }, status: :not_found
+    end
+  end
+
+  def show_shared_song
+    shared_song_data = SharedSongsService.call(
+      user_id: current_user&.id
+    )
+    if shared_song_data.present?
+      render json: shared_song_data, status: :ok
+    else
+      render json: { shared_song_data: [], "message": 共有された曲はまだありません}, status: :ok
     end
   end
 end

--- a/app/services/shared_songs_service.rb
+++ b/app/services/shared_songs_service.rb
@@ -11,7 +11,7 @@ class SharedSongsService
   def fetch_shared_songs_by_user_id(user_id)
     shared_songs_ids = UsersSharedSong.where(user_id: user_id).pluck(:song_id)
     songs_with_artist = Song.where(id: shared_songs_ids).includes(:artist)
-    return songs_with_artist.map do |song|
+    songs_with_artist.map do |song|
       {
         song_id: song.id,
         song_name: song.name,

--- a/app/services/shared_songs_service.rb
+++ b/app/services/shared_songs_service.rb
@@ -11,7 +11,7 @@ class SharedSongsService
   def fetch_shared_songs_by_user_id(user_id)
     shared_songs_ids = UsersSharedSong.where(user_id: user_id).pluck(:song_id)
     songs_with_artist = Song.where(id: shared_songs_ids).includes(:artist)
-    song_data = songs_with_artist.map do |song|
+    return songs_with_artist.map do |song|
       {
         song_id: song.id,
         song_name: song.name,
@@ -19,6 +19,5 @@ class SharedSongsService
         artist_name: song.artist.name
       }
     end
-    song_data
   end
 end

--- a/app/services/shared_songs_service.rb
+++ b/app/services/shared_songs_service.rb
@@ -5,8 +5,7 @@ class SharedSongsService
   end
 
   def call
-    song_data = fetch_shared_songs_by_user_id(@user_id)
-    song_data
+    fetch_shared_songs_by_user_id(@user_id)
   end
 
   def fetch_shared_songs_by_user_id(user_id)

--- a/app/services/shared_songs_service.rb
+++ b/app/services/shared_songs_service.rb
@@ -1,0 +1,25 @@
+class SharedSongsService
+  include Callable
+  def initialize(user_id:)
+    @user_id = user_id
+  end
+
+  def call
+    song_data = fetch_shared_songs_by_user_id(@user_id)
+    song_data
+  end
+
+  def fetch_shared_songs_by_user_id(user_id)
+    shared_songs_ids = UsersSharedSong.where(user_id: user_id).pluck(:song_id)
+    songs_with_artist = Song.where(id: shared_songs_ids).includes(:artist)
+    song_data = songs_with_artist.map do |song|
+      {
+        song_id: song.id,
+        song_name: song.name,
+        song_picture_url: song.picture_url,
+        artist_name: song.artist.name
+      }
+    end
+    song_data
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
         registrations: "users/registrations"
       }
       get "player/songs/:id", to: "songs/songs#show"
+      get "users/shared/songs", to: "songs/songs#show_shared_song"
 end


### PR DESCRIPTION
## 実施したタスク
共有された曲としてusers_shared_songsテーブルに保存された楽曲の情報を全件取得するAPIを作成しました

1. 新しいエンドポイント /users/shared/songs の追加
2. 共有楽曲データを処理する SharedSongsService の実装
3. 認証機能付きのコントローラーアクション show_shared_song の追加

## エンドポイント
http://localhost:3000/users/received/songs
return
```
[
    {
        "song_id": 1,
        "song_name": "Pretender",
        "song_picture_url": "https://example.com/songs/pretender/jacket.jpg",
        "artist_name": "Official髭男dism"
    },
    {
        "song_id": 2,
        "song_name": "Subtitle",
        "song_picture_url": "https://example.com/songs/subtitle/jacket.jpg",
        "artist_name": "Official髭男dism"
    }
]
```
## 詳細
ダッシュボードで曲一覧を取得する想定で作成。authenticate!をAPIにつけてるのでこのエンドポイントには認証済みのユーザーしかアクセスできません。
それ以外は弾くのでフロントでログイン画面に誘導するなどしてください。


