### PR TITLE
楽曲作成APIの作成

### DIFF
--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -1,5 +1,5 @@
 class Songs::SongsController < ApplicationController
-  before_action :authenticate_user!, only: [ :show_shared_song, :register_sharable_song]
+  before_action :authenticate_user!, only: [ :show_shared_song, :register_sharable_song ]
   def show
     song_data = PlaySongService.call(
       song_id: params[:id],
@@ -49,9 +49,9 @@ class Songs::SongsController < ApplicationController
     )
     case status
     when :ok
-      render json: { data: result}
+      render json: { data: result }
     when :error
-      render jdon: { data: result}
+      render jdon: { data: result }
     end
   end
 end

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -1,5 +1,5 @@
 class Songs::SongsController < ApplicationController
-  before_action :authenticate_user!, only: [ :show_shared_song, :regist_sharable_song]
+  before_action :authenticate_user!, only: [ :show_shared_song, :register_sharable_song]
   def show
     song_data = PlaySongService.call(
       song_id: params[:id],
@@ -35,6 +35,23 @@ class Songs::SongsController < ApplicationController
       render json: { data: result }
     when :error
       render json: { error_code: result }
+    end
+  end
+
+  def create_song
+    status, result = CreateSongWithPasswordService.call(
+      name: params[:name],
+      source_url: params[:source_url],
+      picture_url: params[:picture_url],
+      spotify_url: params[:spotify_url],
+      apple_url: params[:apple_url],
+      artist_name: params[:artist_name]
+    )
+    case status
+    when :ok
+      render json: { data: result}
+    when :error
+      render jdon: { data: result}
     end
   end
 end

--- a/app/services/create_song_with_password_service.rb
+++ b/app/services/create_song_with_password_service.rb
@@ -1,3 +1,46 @@
 class CreateSongWithPasswordService
   include Callable
+  def initialize(
+    name:,
+    source_url:,
+    picture_url:,
+    spotify_url: nil,
+    apple_url: nil,
+    artist_name:
+  )
+  @name = name
+  @source_url = source_url
+  @picture_url = picture_url
+  @spotify_url = spotify_url
+  @apple_url = apple_url
+  @artist_name = artist_name
+  end
+
+  def call
+    add_song(@name, @source_url, @picture_url, @spotify_url, @apple_url, @artist_name)
+  end
+
+  def add_song(name, source_url, picture_url, spotify_url, apple_url, artist_name)
+    password = SecureRandom.hex(4)
+    artist = Artist.find_by!(name: artist_name)
+    ActiveRecord::Base.transaction do
+    song = Song.create!(
+      name: name,
+      source_url: source_url,
+      picture_url: picture_url,
+      spotify_url: spotify_url,
+      apple_url: apple_url,
+      artist: artist
+    )
+
+    SongsPassword.create!(
+      song_id: song.id,
+      password: password
+    )
+    end
+  [ :ok, password ]
+
+  rescue ActiveRecord::RecordInvalid => e
+  [ :error, e.record.errors.full_messages ]
+  end
 end

--- a/app/services/share_song_service.rb
+++ b/app/services/share_song_service.rb
@@ -14,9 +14,9 @@ class ShareSongService
       password_setting = SongsPassword.find_by(song_id: song_id)
       if password_setting&.authenticate(password)
         song = UsersSong.create(user_id: user_id, song_id: song_id)
-        return [ :ok, song ]
+        [ :ok, song ]
       else
-        return [ :error, :wrong_password ]
+        [ :error, :wrong_password ]
       end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
       get "player/songs/:id", to: "songs/songs#show"
       get "users/shared/songs", to: "songs/songs#show_shared_song"
       post "users/songs/:song_id/unlock", to: "songs/songs#register_sharable_song"
+      post "songs", to: "songs/songs#create_song"
 end

--- a/db/migrate/20251006061808_rename_column_to_songs_password.rb
+++ b/db/migrate/20251006061808_rename_column_to_songs_password.rb
@@ -1,6 +1,6 @@
 class RenameColumnToSongsPassword < ActiveRecord::Migration[8.0]
   def change
     rename_column :songs_passwords, :songs_id, :song_id
-    #Ex:- rename_column("admin_users", "pasword","hashed_pasword")
+    # Ex:- rename_column("admin_users", "pasword","hashed_pasword")
   end
 end

--- a/db/migrate/20251006070321_rename_columns_to_users_songs.rb
+++ b/db/migrate/20251006070321_rename_columns_to_users_songs.rb
@@ -2,6 +2,6 @@ class RenameColumnsToUsersSongs < ActiveRecord::Migration[8.0]
   def change
     rename_column :users_songs, :songs_id, :song_id
     rename_column :users_songs, :users_id, :user_id
-    #Ex:- rename_column("admin_users", "pasword","hashed_pasword")
+    # Ex:- rename_column("admin_users", "pasword","hashed_pasword")
   end
 end


### PR DESCRIPTION
## 実施したタスク
Songテーブルに楽曲を新たに作成するAPIを作成した。作成時パスワードが返ってくる

1. CreateSongWithPasswordServiceの作成
2. serviceクラスないにadd_songメソッドの実装
3. songsControllerないにcreate_songメソッドの実装

POST　http://localhost:3000/songs
body
`{
  "name": "変な曲",
  "source_url": "https://storage.example.com/songs/pretender.mp3",
  "picture_url": "https://example.com/songs/pretender/jacket.jpg",
  "spotify_url": "https://open.spotify.com/track/15n0n0gT5b6d5g4g3f4g3g",
  "apple_url": "https://music.apple.com/jp/album/pretender/1462432842?i=1462432845",
  "artist_name": "Official髭男dism"
}`
return
`{
    "data": "0b346327"
}`

## 詳細
artistに紐づけるためにartist_nameを入力する必要があるため、artistが存在することが前提である。
