### PR TITLE
共有できる楽曲を一覧取得するAPIの作成

### DIFF
--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -1,6 +1,6 @@
 class Songs::SongsController < ApplicationController
   include Devise::Controllers::Helpers
-  before_action :authenticate_user!, only: [ :show_shared_song, :register_sharable_song ]
+  before_action :authenticate_user!, only: [ :show_shared_song, :register_sharable_song, :show_sharable_song]
   # あとでここにcreate_song追加
   def show
     song_data = PlaySongService.call(
@@ -56,4 +56,16 @@ class Songs::SongsController < ApplicationController
       render json: { data: result }
     end
   end
+
+  def show_sharable_song
+    songs_data = SharableSongsService.call(
+      user_id: current_user.id
+    )
+    if songs_data.present?
+      render json: songs_data
+    else
+      render json: {"message": "共有できる曲はまだありません"}
+    end
+  end
+
 end

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -16,7 +16,7 @@ class Songs::SongsController < ApplicationController
   end
 
   def show_shared_song
-    shared_song_data = SharedSongsService.call(
+    shared_song_data = FetchSharedSongsService.call(
       user_id: current_user&.id
     )
     if shared_song_data.present?

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -27,7 +27,7 @@ class Songs::SongsController < ApplicationController
   end
 
   def register_sharable_song
-    status, result = ShareSongService.call(
+    status, result = RegisterShareSongService.call(
       user_id: current_user&.id,
       song_id: params[:song_id],
       password: params[:password]

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -1,6 +1,6 @@
 class Songs::SongsController < ApplicationController
   include Devise::Controllers::Helpers
-  before_action :authenticate_user!, only: [ :show_shared_song, :register_sharable_song, :show_sharable_song]
+  before_action :authenticate_user!, only: [ :show_shared_song, :register_sharable_song, :show_sharable_song ]
   # あとでここにcreate_song追加
   def show
     song_data = PlaySongService.call(
@@ -64,8 +64,7 @@ class Songs::SongsController < ApplicationController
     if songs_data.present?
       render json: songs_data
     else
-      render json: {"message": "共有できる曲はまだありません"}
+      render json: { "message": "共有できる曲はまだありません" }
     end
   end
-
 end

--- a/app/services/fetch_shared_songs_service.rb
+++ b/app/services/fetch_shared_songs_service.rb
@@ -1,4 +1,4 @@
-class SharedSongsService
+class FetchSharedSongsService
   include Callable
   def initialize(user_id:)
     @user_id = user_id

--- a/app/services/register_share_song_service.rb
+++ b/app/services/register_share_song_service.rb
@@ -1,4 +1,4 @@
-class ShareSongService
+class RegisterShareSongService
   include Callable
   def initialize(user_id:, song_id:, password:)
       @user_id = user_id

--- a/app/services/sharable_songs_service.rb
+++ b/app/services/sharable_songs_service.rb
@@ -1,0 +1,24 @@
+class SharableSongsService
+  include Callable
+  def initialize(user_id:)
+    @user_id = user_id
+  end
+
+  def call
+    fetch_song(@user_id)
+  end
+
+  def fetch_song(user_id)
+    songs = UsersSong.where(user_id: user_id).includes(song: :artist)
+    songs.map do |fetch_song|
+       song = fetch_song.song
+       artist = song.artist
+      {
+        song_id: song.id,
+        song_name: song.name,
+        artist_name: artist.name,
+        song_picture_url: song.picture_url
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
       get "users/shared/songs", to: "songs/songs#show_shared_song"
       post "users/songs/:song_id/unlock", to: "songs/songs#register_sharable_song"
       post "songs", to: "songs/songs#create_song"
+      get "users/songs", to: "songs/songs#show_sharable_song"
 end


### PR DESCRIPTION
## 実施した内容
ユーザーが共有可能な楽曲を一覧取得するAPIの作成を行った。

エンドポイント
GET /users/songs
```
[
    {
        "song_id": 29,
        "song_name": "Subtitle",
        "artist_name": "Official髭男dism",
        "song_picture_url": "https://example.com/songs/subtitle/jacket.jpg"
    },
    {
        "song_id": 30,
        "song_name": "夜に駆ける",
        "artist_name": "YOASOBI",
        "song_picture_url": "https://example.com/songs/yorunikakeru/jacket.jpg"
    }
]
```

## 実施内容詳細
新しくAPI作成にあたり、サービスクラスの命名の見直しをおこなった。
・SharedSongServiceをFetchSharedSongServiceに
・新しくFetchSharableSongsServiceの作成
サービスクラスの命名に関しては要相談。