### PR TITLE
共有した楽曲と回数を取得するAPIの作成

### DIFF
--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -1,6 +1,6 @@
 class Songs::SongsController < ApplicationController
   include Devise::Controllers::Helpers
-  before_action :authenticate_user!, only: [ :show_shared_song, :register_sharable_song, :show_sharable_song ]
+  before_action :authenticate_user!, only: [ :show_received_song, :register_sharable_song, :show_sharable_song, :show_shared_song]
   # あとでここにcreate_song追加
   def show
     song_data = PlaySongService.call(
@@ -15,7 +15,7 @@ class Songs::SongsController < ApplicationController
     end
   end
 
-  def show_shared_song
+  def show_received_song
     shared_song_data = FetchReceivedSongsService.call(
       user_id: current_user&.id
     )
@@ -65,6 +65,17 @@ class Songs::SongsController < ApplicationController
       render json: songs_data
     else
       render json: { "message": "共有できる曲はまだありません" }
+    end
+  end
+
+  def fetch_shared_song
+    songs_data = FetchSharedSongsService.call(
+      share_id: current_user.share_id
+    )
+    if songs_data.present?
+      render json: songs_data
+    else
+      render json: { "message": "まだ共有をしていません"}
     end
   end
 end

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -16,7 +16,7 @@ class Songs::SongsController < ApplicationController
   end
 
   def show_shared_song
-    shared_song_data = FetchSharedSongsService.call(
+    shared_song_data = FetchReceivedSongsService.call(
       user_id: current_user&.id
     )
     if shared_song_data.present?
@@ -58,7 +58,7 @@ class Songs::SongsController < ApplicationController
   end
 
   def show_sharable_song
-    songs_data = SharableSongsService.call(
+    songs_data = FetchSharableSongsService.call(
       user_id: current_user.id
     )
     if songs_data.present?

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -1,6 +1,6 @@
 class Songs::SongsController < ApplicationController
   include Devise::Controllers::Helpers
-  before_action :authenticate_user!, only: [ :show_received_song, :register_sharable_song, :show_sharable_song, :show_shared_song]
+  before_action :authenticate_user!, only: [ :show_received_song, :register_sharable_song, :show_sharable_song, :show_shared_song ]
   # あとでここにcreate_song追加
   def show
     song_data = PlaySongService.call(
@@ -68,14 +68,14 @@ class Songs::SongsController < ApplicationController
     end
   end
 
-  def fetch_shared_song
+  def show_shared_song
     songs_data = FetchSharedSongsService.call(
       share_id: current_user.share_id
     )
     if songs_data.present?
       render json: songs_data
     else
-      render json: { "message": "まだ共有をしていません"}
+      render json: { "message": "まだ共有をしていません" }
     end
   end
 end

--- a/app/services/fetch_received_songs_service.rb
+++ b/app/services/fetch_received_songs_service.rb
@@ -1,16 +1,16 @@
-class FetchSharedSongsService
+class FetchReceivedSongsService
   include Callable
   def initialize(user_id:)
     @user_id = user_id
   end
 
   def call
-    fetch_shared_songs_by_user_id(@user_id)
+    fetch_received_songs_by_user_id(@user_id)
   end
 
-  def fetch_shared_songs_by_user_id(user_id)
-    shared_songs_ids = UsersSharedSong.where(user_id: user_id).pluck(:song_id)
-    songs_with_artist = Song.where(id: shared_songs_ids).includes(:artist)
+  def fetch_received_songs_by_user_id(user_id)
+    received_songs_ids = UsersSharedSong.where(user_id: user_id).pluck(:song_id)
+    songs_with_artist = Song.where(id: received_songs_ids).includes(:artist)
     songs_with_artist.map do |song|
       {
         song_id: song.id,

--- a/app/services/fetch_sharable_songs_service.rb
+++ b/app/services/fetch_sharable_songs_service.rb
@@ -1,4 +1,4 @@
-class SharableSongsService
+class FetchSharableSongsService
   include Callable
   def initialize(user_id:)
     @user_id = user_id

--- a/app/services/fetch_shared_songs.service.rb
+++ b/app/services/fetch_shared_songs.service.rb
@@ -1,0 +1,22 @@
+class FetchSharedSongsService
+  def initialize(share_id:)
+    @share_id = share_id
+  end
+
+  def call
+    fetch_songs(@share_id)
+  end
+
+  def fetch_songs(share_id)
+    count_data = SharedCount.where(share_id: share_id).includes(song: :artist)
+    count_data.map do |data|
+      song = data.song
+      {
+        "name": song.name,
+        "artist_name": song.artist.name,
+        "count": data.count,
+        "song_id": song.id
+      }
+    end
+  end
+end

--- a/app/services/fetch_shared_songs_service.rb
+++ b/app/services/fetch_shared_songs_service.rb
@@ -1,4 +1,5 @@
 class FetchSharedSongsService
+  include Callable
   def initialize(share_id:)
     @share_id = share_id
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
         registrations: "users/registrations"
       }
       get "player/songs/:id", to: "songs/songs#show"
-      get "users/shared/songs", to: "songs/songs#show_shared_song"
+      get "users/received/shared/songs", to: "songs/songs#show_shared_song"
       post "users/songs/:song_id/unlock", to: "songs/songs#register_sharable_song"
       post "songs", to: "songs/songs#create_song"
       get "users/songs", to: "songs/songs#show_sharable_song"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,9 @@ Rails.application.routes.draw do
         registrations: "users/registrations"
       }
       get "player/songs/:id", to: "songs/songs#show"
-      get "users/received/shared/songs", to: "songs/songs#show_shared_song"
+      get "users/received/songs", to: "songs/songs#show_received_song"
       post "users/songs/:song_id/unlock", to: "songs/songs#register_sharable_song"
       post "songs", to: "songs/songs#create_song"
       get "users/songs", to: "songs/songs#show_sharable_song"
+      get "users/shared/songs", to: "songs/songs#show_shared_song"
 end


### PR DESCRIPTION
## 実装した内容
ユーザーが共有した楽曲情報と回数を取得するAPIの作成
共有した、共有された、どちらもsharedになってしまったので、共有された側をreceivedとしてファイル名の変更を行った。

### エンドポイント
共有された楽曲の取得API `users/shared/songs→users/received/songs`
共有した楽曲の取得API 
GET `users/shared/songs`
response
```
[
    {
        "name": "Subtitle",
        "artist_name": "Official髭男dism",
        "count": 4,
        "song_id": 29
    },
    {
        "name": "夜に駆ける",
        "artist_name": "YOASOBI",
        "count": 1,
        "song_id": 30
    }
]
```


