### PR TITLE
曲共有ランキング取得API作成

### DIFF
--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -83,6 +83,6 @@ class Songs::SongsController < ApplicationController
     data = FetchShareRanking.call(
       artist_id: params[:artist_id]
     )
-    render json: { data: ranking }, status: :ok
+    render json: { data: data }, status: :ok
   end
 end

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -62,9 +62,9 @@ class Songs::SongsController < ApplicationController
       user_id: current_user.id
     )
     if songs_data.present?
-      render json: songs_data
+      render json: songs_data , status: :ok
     else
-      render json: { "message": "共有できる曲はまだありません" }
+      render json: { "message": "共有できる曲はまだありません" }, status: :ok
     end
   end
 
@@ -75,7 +75,14 @@ class Songs::SongsController < ApplicationController
     if songs_data.present?
       render json: songs_data
     else
-      render json: { "message": "まだ共有をしていません" }
+      render json: { "message": "まだ共有をしていません" }, status: :ok
     end
+  end
+
+  def show_share_ranking_by_artist_id
+    data = FetchShareRanking.call(
+      artist_id: params[:artist_id]
+    )
+    render json: { data: ranking }, status: :ok
   end
 end

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -62,7 +62,7 @@ class Songs::SongsController < ApplicationController
       user_id: current_user.id
     )
     if songs_data.present?
-      render json: songs_data , status: :ok
+      render json: songs_data, status: :ok
     else
       render json: { "message": "共有できる曲はまだありません" }, status: :ok
     end

--- a/app/services/fetch_share_ranking.rb
+++ b/app/services/fetch_share_ranking.rb
@@ -1,0 +1,32 @@
+class FetchShareRanking
+  include Callable
+  def initialize(artist_id:)
+    @artist_id = artist_id
+  end
+
+  def call
+    fetch_raking(@artist_id)
+  end
+
+  def fetch_raking(artist_id)
+    results = SharedCount
+        .joins(:user, :song)
+        .where(songs: {artist_id: artist_id})
+        .select(
+          "users.name AS user_name,
+          songs.name AS song_name,
+          song.picture_url AS picture_url,
+          shared_counts.count AS shared_count"
+        )
+        .order("shared_counts.count DESC")
+        .limit(3)
+    results.map do |data|
+      {
+        user_name: data.user_name,
+        song_name: data.song_name,
+        picture_url: data.picture_url,
+        count: shared_count
+      }
+    end
+  end
+end

--- a/app/services/fetch_share_ranking.rb
+++ b/app/services/fetch_share_ranking.rb
@@ -11,7 +11,7 @@ class FetchShareRanking
   def fetch_raking(artist_id)
     results = SharedCount
         .joins(:user, :song)
-        .where(songs: {artist_id: artist_id})
+        .where(songs: { artist_id: artist_id })
         .select(
           "users.name AS user_name,
           songs.name AS song_name,

--- a/app/services/fetch_share_ranking.rb
+++ b/app/services/fetch_share_ranking.rb
@@ -9,13 +9,12 @@ class FetchShareRanking
   end
 
   def fetch_raking(artist_id)
-    results = SharedCount
-        .joins(:user, :song)
+    results = SharedCount.joins(:user, :song)
         .where(songs: { artist_id: artist_id })
         .select(
           "users.name AS user_name,
           songs.name AS song_name,
-          song.picture_url AS picture_url,
+          songs.picture_url AS picture_url,
           shared_counts.count AS shared_count"
         )
         .order("shared_counts.count DESC")
@@ -25,7 +24,7 @@ class FetchShareRanking
         user_name: data.user_name,
         song_name: data.song_name,
         picture_url: data.picture_url,
-        count: shared_count
+        count: data.shared_count
       }
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,5 @@ Rails.application.routes.draw do
       post "songs", to: "songs/songs#create_song"
       get "users/songs", to: "songs/songs#show_sharable_song"
       get "users/shared/songs", to: "songs/songs#show_shared_song"
+      get "ranking/:artist_id", to: "songs/songs#show_share_ranking_by_artist_id"
 end


### PR DESCRIPTION
# 概要
artist_idを指定して、指定されたアーティストが持つ楽曲が誰に何回再生されたかのランキングを取得することができるAPIの作成を行った。



## 方針
アーティスト画面で叩くことを想定しているので、画面に表示する領域的に共有回数が多い順に３件取得するようにした。


## 相談・気持ち (任意)
3から増やしてもいいかも。
認証権限を必要としてないので、artist側のログインも作ってもいいかもしれない。





