### PR TITLE
特定APIにセッション(認証)不要の設定を追加

### DIFF
--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -1,6 +1,6 @@
 class Songs::SongsController < ApplicationController
   include Devise::Controllers::Helpers
-  before_action :authenticate_user!, only: [ :show_received_song, :register_sharable_song, :show_sharable_song, :show_shared_song ]
+  skip_before_action :authenticate_user!, only: [ :show, :show_share_ranking_by_artist_id]
   # あとでここにcreate_song追加
   def show
     song_data = Songs::PlaySongService.call(

--- a/app/controllers/songs/songs_controller.rb
+++ b/app/controllers/songs/songs_controller.rb
@@ -1,6 +1,6 @@
 class Songs::SongsController < ApplicationController
   include Devise::Controllers::Helpers
-  skip_before_action :authenticate_user!, only: [ :show, :show_share_ranking_by_artist_id]
+  skip_before_action :authenticate_user!, only: [ :show, :show_share_ranking_by_artist_id ]
   # あとでここにcreate_song追加
   def show
     song_data = Songs::PlaySongService.call(


### PR DESCRIPTION
# 概要
SongsControllerの楽曲取得APIとランキング取得APIを叩くのに認証が不要になる

## 方針
いままでコントローラー内でbefore_actionでatuhenticateを認証が必要なAPIに入れていたが、application_controllerでauthenticateを入れていたのを忘れていた。
そのため、skip_before_actionで認証処理が不要なAPIを弾いた。


## 相談・気持ち (任意)
テストで回避できたのだろうか、この見逃し
## WIP

- [ ] wip が外れる条件




