### PR TITLE
MySqlからpostgreSQLに移行

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:3.4.4
 
 # Node.js, npm, yarn, MySQL client
 RUN apt-get update -qq && \
-    apt-get install -y nodejs npm yarnpkg default-mysql-client && \
+    apt-get install -y nodejs npm yarnpkg postgresql-client && \
     ln -s /usr/bin/yarnpkg /usr/bin/yarn
 
 WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 8.0.3"
 # Use sqlite3 as the database for Active Record
-gem "mysql2", ">= 0.5"
+gem "pg"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,8 +159,6 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
-    mysql2 (0.5.7)
-      bigdecimal
     net-imap (0.5.11)
       date
       net-protocol
@@ -196,6 +194,12 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
+    pg (1.6.2)
+    pg (1.6.2-aarch64-linux)
+    pg (1.6.2-aarch64-linux-musl)
+    pg (1.6.2-arm64-darwin)
+    pg (1.6.2-x86_64-linux)
+    pg (1.6.2-x86_64-linux-musl)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -364,7 +368,7 @@ DEPENDENCIES
   devise (~> 4.9)
   devise-jwt (~> 0.12.1)
   kamal
-  mysql2 (>= 0.5)
+  pg
   pry-rails
   puma (>= 5.0)
   rack-cors

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,6 @@
 default: &default
-  adapter: mysql2
-  encoding: utf8mb4
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: app_user
   password: app_pass
@@ -13,12 +13,12 @@ development:
 test:
   <<: *default
   database: app_test
-  username: root
-  password: MYSQL_ROOT_PASSWORD
+  username: app_user
+  password: app_pass
   host: db
 
 production:
   <<: *default
   database: app_production
-  username: <%= ENV['MYSQL_USER'] %>
-  password: <%= ENV['MYSQL_PASSWORD'] %>
+  username: <%= ENV['POSTGRES_USER'] %>
+  password: <%= ENV['POSTGRES_PASSWORD'] %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,10 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 2025_10_06_070321) do
-  create_table "artists", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "artists", force: :cascade do |t|
     t.string "picture_url"
     t.string "spotify_url"
     t.string "apple_url"
@@ -21,7 +24,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_070321) do
     t.string "name"
   end
 
-  create_table "jwt_denylist", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "jwt_denylist", force: :cascade do |t|
     t.string "jti", null: false
     t.datetime "exp", null: false
     t.datetime "created_at", null: false
@@ -29,7 +32,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_070321) do
     t.index ["jti"], name: "index_jwt_denylist_on_jti", unique: true
   end
 
-  create_table "shared_counts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "shared_counts", force: :cascade do |t|
     t.string "share_id", null: false
     t.bigint "song_id", null: false
     t.integer "count", default: 0, null: false
@@ -39,7 +42,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_070321) do
     t.index ["song_id"], name: "index_shared_counts_on_song_id"
   end
 
-  create_table "songs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "songs", force: :cascade do |t|
     t.string "name"
     t.string "source_url"
     t.string "picture_url"
@@ -51,7 +54,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_070321) do
     t.index ["artist_id"], name: "index_songs_on_artist_id"
   end
 
-  create_table "songs_passwords", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "songs_passwords", force: :cascade do |t|
     t.bigint "song_id", null: false
     t.string "password_digest"
     t.datetime "created_at", null: false
@@ -59,7 +62,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_070321) do
     t.index ["song_id"], name: "index_songs_passwords_on_song_id"
   end
 
-  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -75,7 +78,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_070321) do
     t.index ["share_id"], name: "index_users_on_share_id", unique: true
   end
 
-  create_table "users_shared_songs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users_shared_songs", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "song_id", null: false
     t.datetime "created_at", null: false
@@ -84,7 +87,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_070321) do
     t.index ["user_id"], name: "index_users_shared_songs_on_user_id"
   end
 
-  create_table "users_songs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users_songs", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "song_id", null: false
     t.datetime "created_at", null: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,16 @@
 services:
   db:
-    image: mysql:8.0
-    container_name: rails-mysql
+    image: postgres:15
+    container_name: rails-postgres
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: MYSQL_ROOT_PASSWORD
-      MYSQL_DATABASE: app_development
-      MYSQL_USER: app_user
-      MYSQL_PASSWORD: app_pass
+      POSTGRES_USER: app_user
+      POSTGRES_PASSWORD: app_pass
+      POSTGRES_DB: app_development
     ports:
-      - '3306:3306'
+      - '5432:5432'
     volumes:
-      - db_data:/var/lib/mysql
+    - db_data:/var/lib/postgresql/data
 
   web:
     build: .


### PR DESCRIPTION
# 概要
使用するDBをpostgresqlに移行した

## 方針
デプロイ先のDBを選定していたところ、Supabaseを使うことで安く済みそうだったので移行することにした。
もともと、MySqlの選定理由としては読み込み性能が強いというイメージとデフォルトがMysqlでドキュメントが多く困った時に助かる、という二つの理由があった。しかし、やはりMVPの形ではあるのでそこまで大きなデプロイ先でなくてよく、予算を考えた時supabaseが上がり、postgresを採用することにした。
