### PR TITLE
Refactor/change error response

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -311,7 +311,7 @@ Devise.setup do |config|
   # config.sign_in_after_change_password = true
 
   config.navigational_formats = []
-  config.skip_session_storage = [:http_auth, :params_auth]
+  config.skip_session_storage = [ :http_auth, :params_auth ]
 
   config.jwt do |jwt|
         jwt.secret = ENV["DEVISE_JWT_SECRET_KEY"]

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 # Assuming you have not yet modified this file, each configuration option below
 # is set to its default value. Note that some are commented out while others
@@ -310,6 +309,9 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+
+  config.navigational_formats = []
+  config.skip_session_storage = [:http_auth, :params_auth]
 
   config.jwt do |jwt|
         jwt.secret = ENV["DEVISE_JWT_SECRET_KEY"]

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,14 +1,13 @@
 Rswag::Api.configure do |c|
-
   # Specify a root folder where Swagger JSON files are located
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.openapi_root = Rails.root.to_s + '/swagger'
+  c.openapi_root = Rails.root.to_s + "/swagger"
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request
   # For example, you could leverage this to dynamically assign the "host" property
   #
-  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
 end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,5 +1,4 @@
 Rswag::Ui.configure do |c|
-
   # List the Swagger endpoints that you want to be documented through the
   # swagger-ui. The first parameter is the path (absolute or relative to the UI
   # host) to the corresponding endpoint and the second is a title that will be
@@ -8,7 +7,7 @@ Rswag::Ui.configure do |c|
   # (under openapi_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  mount Rswag::Api::Engine => '/api-docs'
-  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => "/api-docs"
+  mount Rswag::Ui::Engine => "/api-docs"
       devise_for :users, path: "", path_names: {
         sign_in: "login",
         sign_out: "logout",


### PR DESCRIPTION
# 概要
 認証が必要なメソッドを叩く時に出るセッションエラー
ログイン時にパスワードやメールアドレスのinvalidエラー
これらが500で帰っていたので全て401のunauthorizedで返すようにAPIモードとして、セッションを使わないことを明示した。

## 方針
swaggerを書くにあたり、エラーを区別させたかった。しかし、今回の実装ではjsonのスキーマ形式でエラーを返却できておらず、一文で内容が返されている。
改良のためFailureappのカスタムクラスの導入やrescue_fomなどを試したが、カスタムクラスではうまく動かず、rescue_formではjson形式でエラーが返却されるものの、全てunauthorized返却で中身が見えなくなってしまった。
これ以上時間を使いたくなかったため、今回は内容を明示するためにスキーマ形式に拘らないようにした。


## 相談・気持ち (任意)
いつかjson形式で返却したい



