### PR TITLE
本番環境用DBとしてsupabaseの設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,9 @@ gem "bcrypt", "~> 3.1.7"
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
-gem "solid_cache"
-gem "solid_queue"
-gem "solid_cable"
+# gem "solid_cache"
+# gem "solid_queue"
+# gem "solid_cable"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,11 +118,6 @@ GEM
     ed25519 (1.4.0)
     erb (5.0.3)
     erubi (1.13.1)
-    et-orbi (1.4.0)
-      tzinfo
-    fugit (1.11.2)
-      et-orbi (~> 1, >= 1.2.11)
-      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -221,7 +216,6 @@ GEM
     public_suffix (6.0.2)
     puma (7.0.4)
       nio4r (~> 2.0)
-    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.2)
     rack-cors (3.0.0)
@@ -334,22 +328,6 @@ GEM
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    solid_cable (3.0.12)
-      actioncable (>= 7.2)
-      activejob (>= 7.2)
-      activerecord (>= 7.2)
-      railties (>= 7.2)
-    solid_cache (1.0.8)
-      activejob (>= 7.2)
-      activerecord (>= 7.2)
-      railties (>= 7.2)
-    solid_queue (1.2.1)
-      activejob (>= 7.1)
-      activerecord (>= 7.1)
-      concurrent-ruby (>= 1.3.1)
-      fugit (~> 1.11.0)
-      railties (>= 7.1)
-      thor (>= 1.3.1)
     sshkit (1.24.0)
       base64
       logger
@@ -414,9 +392,6 @@ DEPENDENCIES
   rswag-specs
   rswag-ui
   rubocop-rails-omakase
-  solid_cable
-  solid_cache
-  solid_queue
   thruster
   tzinfo-data
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -9,9 +9,4 @@ test:
   adapter: test
 
 production:
-  adapter: solid_cable
-  connects_to:
-    database:
-      writing: cable
-  polling_interval: 0.1.seconds
-  message_retention: 1.day
+  adapter: async

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,13 +2,15 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: app_user
-  password: app_pass
-  host: db
+  timeout: 5000
 
 development:
   <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
+  database: <%= ENV.fetch("DATABASE_NAME") %>
+  username: <%= ENV.fetch("DATABASE_USERNAME") %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD") %>
+  host: <%= ENV.fetch("DATABASE_HOST") %>
+  port: <%= ENV.fetch("DATABASE_PORT") { 5432 } %>
 
 test:
   <<: *default
@@ -16,9 +18,8 @@ test:
   username: app_user
   password: app_pass
   host: db
+  port: 5432
 
 production:
   <<: *default
-  database: app_production
-  username: <%= ENV['POSTGRES_USER'] %>
-  password: <%= ENV['POSTGRES_PASSWORD'] %>
+  url: <%= ENV["DATABASE_URL"] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,7 +8,7 @@ default: &default
 
 development:
   <<: *default
-  database: app_development
+  url: <%= ENV["DATABASE_URL"] %>
 
 test:
   <<: *default

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,11 +44,12 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :solid_cache_store
+  # config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+
+  # config.active_job.queue_adapter = :solid_queue
+  # config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,22 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 2025_10_06_070321) do
+  create_schema "auth"
+  create_schema "extensions"
+  create_schema "graphql"
+  create_schema "graphql_public"
+  create_schema "pgbouncer"
+  create_schema "realtime"
+  create_schema "storage"
+  create_schema "vault"
+
   # These are extensions that must be enabled in order to support this database
+  enable_extension "extensions.pg_stat_statements"
+  enable_extension "extensions.pgcrypto"
+  enable_extension "extensions.uuid-ossp"
+  enable_extension "graphql.pg_graphql"
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "vault.supabase_vault"
 
   create_table "artists", force: :cascade do |t|
     t.string "picture_url"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 services:
-  # db:
-  #   image: postgres:15
-  #   container_name: rails-postgres
-  #   restart: always
-  #   environment:
-  #     POSTGRES_USER: app_user
-  #     POSTGRES_PASSWORD: app_pass
-  #     POSTGRES_DB: app_development
-  #   ports:
-  #     - '5432:5432'
-  #   volumes:
-  #   - db_data:/var/lib/postgresql/data
+  db:
+    image: postgres:15
+    container_name: rails-postgres
+    restart: always
+    environment:
+      POSTGRES_USER: app_user
+      POSTGRES_PASSWORD: app_pass
+      POSTGRES_DB: app_development
+    ports:
+      - '5432:5432'
+    volumes:
+    - db_data:/var/lib/postgresql/data
 
   web:
     build: .
@@ -21,8 +21,8 @@ services:
     ports:
       - '3000:3000'
     # supabaseを使うときは依存しない
-    # depends_on:
-    #   - db
+    depends_on:
+      - db
     env_file:
       - .env
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 services:
-  db:
-    image: postgres:15
-    container_name: rails-postgres
-    restart: always
-    environment:
-      POSTGRES_USER: app_user
-      POSTGRES_PASSWORD: app_pass
-      POSTGRES_DB: app_development
-    ports:
-      - '5432:5432'
-    volumes:
-    - db_data:/var/lib/postgresql/data
+  # db:
+  #   image: postgres:15
+  #   container_name: rails-postgres
+  #   restart: always
+  #   environment:
+  #     POSTGRES_USER: app_user
+  #     POSTGRES_PASSWORD: app_pass
+  #     POSTGRES_DB: app_development
+  #   ports:
+  #     - '5432:5432'
+  #   volumes:
+  #   - db_data:/var/lib/postgresql/data
 
   web:
     build: .
@@ -20,8 +20,9 @@ services:
       - .:/app
     ports:
       - '3000:3000'
-    depends_on:
-      - db
+    # supabaseを使うときは依存しない
+    # depends_on:
+    #   - db
     env_file:
       - .env
 


### PR DESCRIPTION
# 概要
本番用のDBでsupabase、開発用のDBでDBコンテナを使ってローカルのDBを使うことにした。
本PRではsupabaseの導入とproduction環境の設定を行った。
productionへ切り替えるとき
- .env
- ・DATABASE_URLのコメントアウト
- ・RAILS_ENVをproductionに変更
- docker-compose.yml
- ・ dbコンテナコメントアウト
- ・web内のdepends_onコメントアウト
developmentへ切り替えるとき
- ・RAILS_ENVをdevelopmentに変更
- ・それ以外は.envの設定の逆


## 方針
production環境を実装するにあたり、cache,queue,cableを用いていないのでgemからコメントアウトした。
それに伴い、environmentsのproduction.rbの関連コードをコメントアウトした。


## 相談・気持ち (任意)
いつかキャッシュとか実装したら変更が必要ですね。





