### PR TITLE
refactor envで生成URLを変更できるように変更

### DIFF
--- a/app/models/song/share_url_generator.rb
+++ b/app/models/song/share_url_generator.rb
@@ -11,7 +11,8 @@ class Song
     end
 
     def generate_share_url(song_id, share_id)
-      "https://nfc-sticker.vercel.app/player/#{song_id}?share_id=#{share_id}"
+      frontend_url = ENV.fetch("FRONTEND_URL", "https://nfc-sticker.vercel.app")
+      "#{frontend_url}/player/#{song_id}?share_id=#{share_id}"
     end
   end
 end


### PR DESCRIPTION
# 概要
songs/{song_id}/share_url
の楽曲共有APIの生成APIのURL部分を実行環境によって変更できるように修正しました。
## 方針
もともと、ローカルのみで動かしていたので一時的にハードコードしていました、ENVファイルに
FRONTEND_URLを作成して、そこになければデプロイしてる本番URLを発行する、という形にしました。
## 実装 (任意)
```
def generate_share_url(song_id, share_id)
      frontend_url = ENV.fetch("FRONTEND_URL", "https://nfc-sticker.vercel.app")
      "#{frontend_url}/player/#{song_id}?share_id=#{share_id}"
end
```
envに指定がなければデフォルトで本番環境のURLを生成します。
