### PR TITLE
Feature/deploy fly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,45 +1,43 @@
-# See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more about ignoring files.
+# Dockerビルドから除外するファイル
+# 必要に応じてコメントアウトを外してください
 
-# Ignore git directory.
-/.git/
-/.gitignore
+# Git
+.git
+.gitignore
 
-# Ignore bundler config.
-/.bundle
+# Logs（本番環境では不要）
+log/*
+tmp/*
+!log/.keep
+!tmp/.keep
 
-# Ignore all environment files.
-/.env*
+# Environment（本番では環境変数で管理）
+.env
+.env.*
 
-# Ignore all default key files.
-/config/master.key
-/config/credentials/*.key
+# Node modules（本番では不要）
+# node_modules/
 
-# Ignore all logfiles and tempfiles.
-/log/*
-/tmp/*
-!/log/.keep
-!/tmp/.keep
+# Test files（本番では不要）
+test/
+spec/
+coverage/
 
-# Ignore pidfiles, but keep the directory.
-/tmp/pids/*
-!/tmp/pids/.keep
+# Documentation（本番では不要）
+# README.md
+# swagger/
 
-# Ignore storage (uploaded files in development and any SQLite databases).
-/storage/*
-!/storage/.keep
-/tmp/storage/*
-!/tmp/storage/.keep
+#tuho Development files（本番では不要）
+# .github/
+# .vscode/
+# .idea/
 
-# Ignore CI service files.
-/.github
+# Storage（本番では外部ストレージ推奨）
+# storage/*
+# !storage/.keep
 
-# Ignore Kamal files.
-/config/deploy*.yml
-/.kamal
-
-# Ignore development files
-/.devcontainer
-
-# Ignore Docker-related files
-/.dockerignore
-/Dockerfile*
+# Temp files
+*.swp
+*.swo
+*~
+.DS_Store

--- a/DEPLOY_FLY_IO.md
+++ b/DEPLOY_FLY_IO.md
@@ -1,0 +1,169 @@
+# Fly.io デプロイガイド
+
+このドキュメントは、nfc-sticker-beをfly.ioの最安プラン（shared-cpu-1x, 256MB RAM）でデプロイする手順を説明します。
+
+## 前提条件
+
+1. fly.ioアカウントの作成
+2. flyctlコマンドのインストール
+
+```bash
+# macOSの場合
+brew install flyctl
+
+# その他のOSはこちら: https://fly.io/docs/hands-on/install-flyctl/
+```
+
+3. ログイン
+```bash
+flyctl auth login
+```
+
+## デプロイ手順
+
+### 1. アプリケーションの作成
+
+```bash
+cd nfc-sticker-be
+flyctl apps create nfc-sticker-be
+```
+
+※ アプリ名が既に使用されている場合は、別の名前を使用してください。その場合は`fly.toml`の`app`も変更してください。
+
+### 2. 環境変数の設定
+
+必要な環境変数を設定します：
+
+```bash
+# データベース接続URL（Supabase等）
+flyctl secrets set DATABASE_URL="postgresql://user:password@host:port/database"
+
+# Rails master key
+flyctl secrets set RAILS_MASTER_KEY="$(cat config/master.key)"
+
+# その他の必要な環境変数
+flyctl secrets set SECRET_KEY_BASE="$(bundle exec rails secret)"
+flyctl secrets set DEVISE_JWT_SECRET_KEY="$(bundle exec rails secret)"
+
+# CORS設定（フロントエンドのURL）
+flyctl secrets set FRONTEND_URL="https://your-frontend-url.com"
+```
+
+### 3. Dockerfileの指定
+
+fly.tomlを編集して、最適化されたDockerfileを使用します：
+
+```toml
+[build]
+  dockerfile = "Dockerfile.fly"
+```
+
+または、デフォルトのDockerfileを使用する場合は：
+
+```toml
+[build]
+```
+
+### 4. デプロイ
+
+```bash
+flyctl deploy
+```
+
+初回デプロイ後、アプリケーションのURLが表示されます。
+
+### 5. デプロイ後の確認
+
+```bash
+# アプリケーションの状態確認
+flyctl status
+
+# ログの確認
+flyctl logs
+
+# アプリケーションを開く
+flyctl open
+```
+
+## 費用最適化設定
+
+### 自動スケーリング設定
+
+`fly.toml`には以下の設定が含まれており、最安プランで運用できます：
+
+- `auto_stop_machines = 'stop'`: リクエストがない時は自動停止
+- `auto_start_machines = true`: リクエストがあれば自動起動
+- `min_machines_running = 0`: アイドル時は0台まで縮小可能
+- `memory = '256mb'`: 最小メモリ
+- `cpu_kind = 'shared'`: 共有CPU
+
+これにより、**使用していない時間は課金されず**、月額費用を大幅に削減できます。
+
+### 推定月額費用
+
+- shared-cpu-1x (256MB): 約 $1.94/月（常時稼働の場合）
+- 自動停止を有効にした場合: 使用時間に応じて更に削減
+
+## トラブルシューティング
+
+### マイグレーションエラー
+
+```bash
+# 手動でマイグレーションを実行
+flyctl ssh console
+bundle exec rails db:migrate
+```
+
+### メモリ不足エラー
+
+もしメモリ不足が発生した場合は、`fly.toml`のメモリを増やします：
+
+```toml
+[[vm]]
+  memory = '512mb'  # 256mb から 512mb へ
+```
+
+### ログの確認
+
+```bash
+# リアルタイムログ
+flyctl logs -a nfc-sticker-be
+
+# 過去のログ
+flyctl logs -a nfc-sticker-be --lines 100
+```
+
+### シークレットの確認
+
+```bash
+flyctl secrets list
+```
+
+## その他のコマンド
+
+```bash
+# SSHでコンソールに接続
+flyctl ssh console
+
+# Railsコンソールの起動
+flyctl ssh console -C "bin/rails console"
+
+# アプリケーションの再起動
+flyctl apps restart
+
+# アプリケーションの削除
+flyctl apps destroy nfc-sticker-be
+```
+
+## 注意事項
+
+1. **データベース**: fly.ioのPostgreSQLは有料です。既存のSupabase等の外部DBを使用することで費用を抑えられます。
+2. **永続ストレージ**: fly.ioのVMは一時的なものです。永続化が必要なデータは外部ストレージを使用してください。
+3. **リージョン**: `fly.toml`では東京リージョン（nrt）を指定していますが、必要に応じて変更できます。
+
+## 参考リンク
+
+- [Fly.io Documentation](https://fly.io/docs/)
+- [Fly.io Pricing](https://fly.io/docs/about/pricing/)
+- [Rails on Fly.io](https://fly.io/docs/rails/getting-started/)
+

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,0 +1,35 @@
+# Fly.io用の最適化されたDockerfile
+FROM ruby:3.4.4-slim
+
+# 必要なパッケージのインストール
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    postgresql-client \
+    libpq-dev \
+    libyaml-dev \
+    nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Gemfileのコピーとインストール
+COPY Gemfile Gemfile.lock ./
+RUN bundle config set --local deployment 'true' && \
+    bundle config set --local without 'development test' && \
+    bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
+
+# アプリケーションコードのコピー
+COPY . .
+
+# アセットのプリコンパイル（必要な場合）
+# RUN bundle exec rails assets:precompile
+
+# 一時ファイルのクリーンアップ
+RUN rm -rf tmp/* log/*
+
+EXPOSE 3000
+
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]
+

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,11 +6,11 @@ default: &default
 
 development:
   <<: *default
-  database: <%= ENV.fetch("DATABASE_NAME") %>
-  username: <%= ENV.fetch("DATABASE_USERNAME") %>
-  password: <%= ENV.fetch("DATABASE_PASSWORD") %>
-  host: <%= ENV.fetch("DATABASE_HOST") %>
-  port: <%= ENV.fetch("DATABASE_PORT") { 5432 } %>
+  database: <%= ENV.fetch("DATABASE_NAME", "app_development") %>
+  username: <%= ENV.fetch("DATABASE_USERNAME", "app_user") %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD", "app_pass") %>
+  host: <%= ENV.fetch("DATABASE_HOST", "localhost") %>
+  port: <%= ENV.fetch("DATABASE_PORT", "5432") %>
 
 test:
   <<: *default

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,36 @@
+# fly.toml app configuration file generated for nfc-sticker-be
+# fly.io最安プラン設定
+
+app = 'nfc-sticker-be'
+primary_region = 'nrt' # 東京リージョン
+
+[build]
+  dockerfile = "Dockerfile.fly"
+
+[deploy]
+  release_command = 'bin/rails db:migrate'
+
+[env]
+  RAILS_ENV = 'production'
+  RAILS_LOG_TO_STDOUT = 'true'
+  RAILS_SERVE_STATIC_FILES = 'true'
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  max_machines_running = 1
+  processes = ['app']
+
+  [http_service.concurrency]
+    type = 'connections'
+    hard_limit = 25
+    soft_limit = 20
+
+[[vm]]
+  memory = '256mb'
+  cpu_kind = 'shared'
+  cpus = 1
+

--- a/fly.toml
+++ b/fly.toml
@@ -20,8 +20,8 @@ primary_region = 'nrt' # 東京リージョン
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
-  max_machines_running = 1
+  min_machines_running = 1
+  max_machines_running = 2
   processes = ['app']
 
   [http_service.concurrency]
@@ -30,7 +30,7 @@ primary_region = 'nrt' # 東京リージョン
     soft_limit = 20
 
 [[vm]]
-  memory = '256mb'
+  memory = '512mb'
   cpu_kind = 'shared'
   cpus = 1
 

--- a/scripts/seed_production.sh
+++ b/scripts/seed_production.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+echo "Running database migration..."
+bin/rails db:migrate
+
+echo "Seeding production database..."
+bin/rails db:seed_production
+
+echo "Production database setup completed!"


### PR DESCRIPTION
# 概要

- この PR をマージすると、Fly.io へのデプロイが可能になります
- 最安プラン（shared-cpu-1x, 512MB RAM）での運用を想定した設定で、自動スケーリング機能により使用していない時間は課金されない構成になっています
- 参照: [Fly.io Documentation](https://fly.io/docs/)

## 方針

- **Fly.io最安プランでの運用を実現**
  - shared CPUと512MBメモリで運用可能な構成
  - auto_stop_machines機能により、リクエストがない時は自動停止して課金を抑える
  - 東京リージョン（nrt）を指定してレイテンシを最小化

- **開発環境への影響を最小限に**
  - 本番デプロイ用のファイル（Dockerfile.fly、fly.toml等）を追加
  - 既存のDockerfile、docker-compose.ymlには影響を与えない
  - database.ymlの環境変数にデフォルト値を追加することで、ローカル開発時の設定忘れを防止

- **ドキュメント整備**
  - DEPLOY_FLY_IO.mdに詳細なデプロイ手順、トラブルシューティング、コマンド一覧を記載
  - 初めてFly.ioを使う人でもデプロイできるよう配慮

- **除外したもの**
  - Fly.io独自のPostgreSQLは使用しない（有料のため）
  - 既存のSupabase等の外部DBを継続利用する方針

### ＊マイグレーションができなかったこととテストのために、一時的にメモリとマシンを増やしています
## 実装

### 主な変更ファイル

1. **DEPLOY_FLY_IO.md**（新規）
   - Fly.ioへのデプロイ手順を網羅的に記載
   - 環境変数の設定方法、トラブルシューティング、各種コマンドを整理

2. **Dockerfile.fly**（新規）
   - 本番環境用に最適化されたDockerfile
   - 不要なパッケージを削減し、イメージサイズを最小化
   - deployment modeでbundle installを実行

3. **fly.toml**
   - 最安プラン設定（512MB RAM、shared CPU）
   - `auto_stop_machines = 'stop'` で自動停止を有効化
   - `min_machines_running = 1` で最低1台は起動状態を維持
   - release_commandでマイグレーションを自動実行

4. **scripts/seed_production.sh**（新規）
   - 本番環境でのマイグレーション+シード実行を一括で行えるスクリプト

5. **.dockerignore**
   - 日本語コメントに変更し、わかりやすく整理
   - 本番環境で不要なファイル（test/, spec/等）を明示的に除外

6. **config/database.yml**
   - 環境変数にデフォルト値を追加
   - ローカル開発時に環境変数が未設定でも動作するように改善


### デプロイ検証項目
```bash
# 以下のコマンドで動作確認
flyctl status  # アプリケーションが起動していることを確認
flyctl logs    # エラーログがないことを確認
curl https://nfc-sticker-be.fly.dev/health  # ヘルスチェックエンドポイントの確認
```

## 相談・気持ち

- **メモリサイズについて**: 現在512MBに設定していますが、実際の使用状況を見て256MBまで下げられる可能性があります。運用しながら調整したいと思います
- **min_machines_running**: 現在1に設定していますが、完全にコストを抑えたい場合は0にすることも検討できます（ただし初回リクエストはコールドスタート）
