### PR TITLE
Feature/fetch shared artist index

### DIFF
--- a/app/controllers/artists/artists_controller.rb
+++ b/app/controllers/artists/artists_controller.rb
@@ -12,4 +12,16 @@ class Artists::ArtistsController < ApplicationController
       render json: { error: "Artist not found" }, status: :not_found
     end
   end
+
+  def index_shared_artist
+    status, result = Artist::SharedArtistFetcher.call(
+      user_id: current_user.id
+    )
+    case status
+    when :ok
+      render json: result
+    when :not_found
+      render json: { error: "Artist not found" }, status: :not_found
+    end
+  end
 end

--- a/app/models/artist/shared_artist_fetcher.rb
+++ b/app/models/artist/shared_artist_fetcher.rb
@@ -12,14 +12,19 @@ class Artist
     def fetch_shared_artist(user_id)
       shared_artists_ids = UsersSharedSong.where(user_id: user_id).pluck(:artist_id)
       artists = Artist.where(id: shared_artists_ids)
-      result = artists.map do |artist|
-        {
-          artist_id: artist.id,
-          artist_name: artist.name,
-          artist_picture_url: artist.picture_url
-        }
+      
+      if artists.empty?
+        [ :not_found, nil ]
+      else
+        result = artists.map do |artist|
+          {
+            artist_id: artist.id,
+            artist_name: artist.name,
+            artist_picture_url: artist.picture_url
+          }
+        end
+        [ :ok, result ]
       end
-      [ :ok, result ]
     end
   end
 end

--- a/app/models/artist/shared_artist_fetcher.rb
+++ b/app/models/artist/shared_artist_fetcher.rb
@@ -1,0 +1,24 @@
+class Artist
+  class SharedArtistFetcher
+    include Callable
+    def initialize(user_id:)
+      @user_id = user_id
+    end
+
+    def call
+      fetch_shared_artist(@user_id)
+    end
+
+    def fetch_shared_artist(user_id)
+      shared_artists_ids = UsersSharedSong.where(user_id: user_id).pluck(:artist_id)
+      artists = Artist.where(id: shared_artists_ids)
+      result = artists.map do |artist|
+        {
+          artist_id: artist.id,
+          artist_name: artist.name
+        }
+      end
+      [ :ok, result ]
+    end
+  end
+end

--- a/app/models/artist/shared_artist_fetcher.rb
+++ b/app/models/artist/shared_artist_fetcher.rb
@@ -15,7 +15,8 @@ class Artist
       result = artists.map do |artist|
         {
           artist_id: artist.id,
-          artist_name: artist.name
+          artist_name: artist.name,
+          artist_picture_url: artist.picture_url
         }
       end
       [ :ok, result ]

--- a/app/models/artist/shared_artist_fetcher.rb
+++ b/app/models/artist/shared_artist_fetcher.rb
@@ -12,7 +12,7 @@ class Artist
     def fetch_shared_artist(user_id)
       shared_artists_ids = UsersSharedSong.where(user_id: user_id).pluck(:artist_id)
       artists = Artist.where(id: shared_artists_ids)
-      
+
       if artists.empty?
         [ :not_found, nil ]
       else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,5 @@ Rails.application.routes.draw do
       get "ranking/:artist_id", to: "songs/songs#show_share_ranking_by_artist_id"
       get "artists/:artist_id", to: "artists/artists#show_artist"
       get "songs/:song_id/share_url", to: "songs/songs#generate_share_url"
+      get "artists/shared", to: "artists/artists#index_shared_artist"
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -714,3 +714,7 @@ components:
           type: string
           description: アーティスト名
           example: Official髭男dism
+        artist_picture_url:
+          type: string
+          description: アーティストの画像URL
+          example: https://example.com/artist.jpg

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -444,6 +444,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SharedArtistData'
+        '404':
+          description: 共有されたアーティストが見つからない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtistNotFoundError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -428,6 +428,25 @@ paths:
               schema:
                 $ref: '#/components/schemas/ArtistNotFoundError'
 
+  /artists/shared:
+    get:
+      summary: 共有されたアーティスト一覧を取得
+      tags: [Artists]
+      security:
+        - BearerAuth: []
+      description: ユーザーが受信した共有楽曲のアーティスト一覧を取得します
+      responses:
+        '200':
+          description: 共有アーティスト一覧取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SharedArtistData'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+
   /songs/{song_id}/share_url:
     get:
       summary: 楽曲の共有URL生成
@@ -683,3 +702,15 @@ components:
         error:
           type: string
           example: Artist not found
+
+    SharedArtistData:
+      type: object
+      properties:
+        artist_id:
+          type: integer
+          description: アーティストの一意なID
+          example: 1
+        artist_name:
+          type: string
+          description: アーティスト名
+          example: Official髭男dism


### PR DESCRIPTION
# 概要
共有された楽曲のアーティストの一覧取得（name, picture_url, artist_id）を行うAPIを実装した。
ホーム画面からアーティストページへアクセスができる様にするためのものである。

## 方針

 **レスポンス形式の統一**: 他のFetcherクラス（`ArtistFetcher`, `SongFetcher`等）と同様に、`SharedArtistFetcher`のレスポンスを `[status, result]` の形式に変更
  - プロジェクト全体で統一されたエラーハンドリングパターンを適用
  - `ArtistFetcher` の実装を参考に、`:ok` ステータスでデータを返す形式に統一
- **Swaggerドキュメントの追加**: `/artists/shared` エンドポイントのAPI仕様を明文化
  - 認証が必要なエンドポイントとして定義
  - レスポンススキーマ `SharedArtistData` を新規追加## 実装 (任意)
- `ArtistFetcher` と同じパターンで `[:ok, result]` を返すように変更
- 現状は常に `:ok` を返すが、将来的にエラーハンドリングを追加する際の拡張性を確保

### 2. コントローラーのクラス名修正

- `Artist::ArtistSharedFetcher` → `Artist::SharedArtistFetcher` に修正
- ファイル名とクラス名の一貫性を保持

### 3. Swagger定義の追加

- エンドポイント: `GET /artists/shared`
- 新規スキーマ: `SharedArtistData` (artist_id, artist_name)
- 認証必須エンドポイントとして定義




