### PR TITLE
Fix fetch shared aritst

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,3 +1,3 @@
 class Artist < ApplicationRecord
-  has_many :song, dependent: :destroy
+  has_many :songs, dependent: :destroy
 end

--- a/app/models/artist/shared_artist_fetcher.rb
+++ b/app/models/artist/shared_artist_fetcher.rb
@@ -10,8 +10,11 @@ class Artist
     end
 
     def fetch_shared_artist(user_id)
-      shared_artists_ids = UsersSharedSong.where(user_id: user_id).pluck(:artist_id)
-      artists = Artist.where(id: shared_artists_ids)
+      # JOINを使って1つのクエリで効率的に取得
+      artists = Artist
+        .joins(songs: :users_shared_songs)
+        .where(users_shared_songs: { user_id: user_id })
+        .distinct
 
       if artists.empty?
         [ :not_found, nil ]

--- a/app/models/artist/shared_artist_fetcher.rb
+++ b/app/models/artist/shared_artist_fetcher.rb
@@ -10,7 +10,7 @@ class Artist
     end
 
     def fetch_shared_artist(user_id)
-      # JOINを使って1つのクエリで効率的に取得
+      # JOINを使用して1つのクエリで効率的に取得
       artists = Artist
         .joins(songs: :users_shared_songs)
         .where(users_shared_songs: { user_id: user_id })

--- a/app/models/artist/shared_artist_fetcher.rb
+++ b/app/models/artist/shared_artist_fetcher.rb
@@ -10,7 +10,6 @@ class Artist
     end
 
     def fetch_shared_artist(user_id)
-      # JOINを使用して1つのクエリで効率的に取得
       artists = Artist
         .joins(songs: :users_shared_songs)
         .where(users_shared_songs: { user_id: user_id })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
       get "users/songs", to: "songs/songs#show_sharable_song"
       get "users/shared/songs", to: "songs/songs#show_shared_song"
       get "ranking/:artist_id", to: "songs/songs#show_share_ranking_by_artist_id"
+      get "artists/shared", to: "artists/artists#index_shared_artist"
       get "artists/:artist_id", to: "artists/artists#show_artist"
       get "songs/:song_id/share_url", to: "songs/songs#generate_share_url"
-      get "artists/shared", to: "artists/artists#index_shared_artist"
 end


### PR DESCRIPTION
共有されたアーティスト情報取得のAPIを修正しました。
リレーションがはられていないモデルから取ろうとしていたのでエラーが発生したものを修正。
無駄なクエリがない様に気を遣いました。
ルーティングもartist_idと判定されない様jに順序の変更を行いました